### PR TITLE
Fix margin() error, add new scale option

### DIFF
--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -176,8 +176,8 @@ class PdfBuilder implements Responsable
         float $left = 0,
         Unit|string $unit = 'in'
     ): self {
-        if (! $unit instanceof Unit) {
-            $unit = Unit::from($unit);
+        if ($unit instanceof Unit) {
+            $unit = $unit->value;
         }
 
         $this->margins = compact(

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -178,9 +178,7 @@ class PdfBuilder implements Responsable
         float $left = 0,
         Unit|string $unit = 'in'
     ): self {
-        if ($unit instanceof Unit) {
-            $unit = $unit->value;
-        }
+        $unit = $this->getUnitValue($unit);
 
         $this->margins = compact(
             'top',
@@ -196,6 +194,7 @@ class PdfBuilder implements Responsable
     public function scale(float $scale): self
     {
         $this->scale = $scale;
+
         return $this;
     }
 
@@ -212,9 +211,7 @@ class PdfBuilder implements Responsable
 
     public function paperSize(float $width, float $height, Unit|string $unit = 'in'): self
     {
-        if ($unit instanceof Unit) {
-            $unit = $unit->value;
-        }
+        $unit = $this->getUnitValue($unit);
 
         $this->paperSize = compact(
             'width',
@@ -223,6 +220,15 @@ class PdfBuilder implements Responsable
         );
 
         return $this;
+    }
+
+    protected function getUnitValue(Unit|string $unit): string
+    {
+        if (! $unit instanceof Unit) {
+            $unit = Unit::from($unit);
+        }
+
+        return $unit->value;
     }
 
     public function customize(callable $callback): self
@@ -363,7 +369,7 @@ class PdfBuilder implements Responsable
         }
 
         $postData['landscape'] = $this->orientation === Orientation::Landscape->value;
-        if($this->scale) {
+        if ($this->scale) {
             $postData['scale'] = $this->scale;
         }
 

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -45,6 +45,8 @@ class PdfBuilder implements Responsable
 
     public ?array $margins = null;
 
+    public ?float $scale = null;
+
     protected string $visibility = 'private';
 
     protected ?Closure $customizeRequest = null;
@@ -188,6 +190,12 @@ class PdfBuilder implements Responsable
             'unit',
         );
 
+        return $this;
+    }
+
+    public function scale(float $scale): self
+    {
+        $this->scale = $scale;
         return $this;
     }
 
@@ -355,6 +363,9 @@ class PdfBuilder implements Responsable
         }
 
         $postData['landscape'] = $this->orientation === Orientation::Landscape->value;
+        if($this->scale) {
+            $postData['scale'] = $this->scale;
+        }
 
         $request->attach('index', $this->getHtml(), 'index.html');
 

--- a/tests/PdfBuilderTest.php
+++ b/tests/PdfBuilderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use SaferMobility\LaravelGotenberg\Enums\Unit;
+use SaferMobility\LaravelGotenberg\PdfBuilder;
+
+test('use string `px` unit to set margin use Enum `Unit::Pixel`', function () {
+    $pdfBuilder = new PdfBuilder;
+
+    expect($pdfBuilder->margins(unit: 'px'))
+        ->toBeObject()
+        ->and($pdfBuilder->margins['unit'])
+        ->toEqual(Unit::Pixel->value);
+});
+
+test('use invalid string `Px` unit to set margin throw an exception', function () {
+    $pdfBuilder = new PdfBuilder;
+    $pdfBuilder->margins(unit: 'Px');
+})->throws(ValueError::class);
+
+test('use string `mm` unit to set paperSize use Enum `Unit::Millimeter`', function () {
+    $pdfBuilder = new PdfBuilder;
+
+    expect($pdfBuilder->paperSize(450, 450, 'mm'))
+        ->toBeObject()
+        ->and($pdfBuilder->paperSize['unit'])
+        ->toEqual(Unit::Millimeter->value);
+});
+
+test('use invalid string `mM` unit to set paperSize throw an exception', function () {
+    $pdfBuilder = new PdfBuilder;
+    expect($pdfBuilder->paperSize(450, 450, 'mM'));
+})->throws(ValueError::class);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "pest()" function to bind a different classes or traits.
+|
+*/
+
+pest()
+    ->extend(SaferMobility\LaravelGotenberg\Tests\TestCase::class)
+    ->in('.');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace SaferMobility\LaravelGotenberg\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+
+class TestCase extends Orchestra {}


### PR DESCRIPTION
Proposed in this MR

- a fix for PHP error on `margin`  function
`Object of class SaferMobility\LaravelGotenberg\Enums\Unit could not be converted to string`

- a new ` scale` option to generate PDF